### PR TITLE
Fix thread list does not synchronously updated

### DIFF
--- a/packages/app/src/panels/thread-list/ThreadListItem.tsx
+++ b/packages/app/src/panels/thread-list/ThreadListItem.tsx
@@ -32,7 +32,7 @@ export function ThreadListItem({
     '& > svg': {
       marginLeft: '5px',
     },
-    '& > div': {
+    '& > p': {
       flexGrow: 1,
       overflow: 'hidden',
       textOverflow: 'elipsis',

--- a/src/features/sidebar.ts
+++ b/src/features/sidebar.ts
@@ -139,11 +139,7 @@ class SidebarProvider implements vscode.WebviewViewProvider {
     }
     await this._threadRepository.save(thread)
     const threads = await this._threadRepository.fetchList()
-    await sendMessage(this._view.webview, {
-      type: 'update-thread-list',
-      source: 'side-buddy-extension',
-      threads,
-    })
+    this.extensionEventEmitter.emit('update-thread', threads)
   }
 
   private async handleLoadThread(threadId: string) {


### PR DESCRIPTION
## Overview
Fix thread list does not synchronously updated.

## Changes Made

- Send the 'update-thread' extension event when the thread updates.

## Testing

![Code_vysQrnGi85](https://user-images.githubusercontent.com/3823428/233840376-c19478d2-3609-452e-9f8d-38809e7e6195.gif)
