### PR TITLE
Fix README to align with Open AI brand guideline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Your friend living in the sidebar, powered by OpenAI API(currently supported gpt-3.5-turbo).
+Your friend living in the sidebar, powered by OpenAI API(GPT3).
 You can specify the role and temperature, and refer to conversation history(shared between Windows/WSL).
 
 ## Requirements


### PR DESCRIPTION
## Overview

The guidelines state that the term 'gpt-3.5-turbo' is not permitted.

https://openai.com/brand

## Changes Made

- Fix README to align with Open AI brand guideline.

